### PR TITLE
Remove debuggable flag from manifest

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,9 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.StupidRat.SysLvl"
       android:versionName="3.2.1" android:versionCode="15">
-    <application 
-    	android:icon="@drawable/icon" 
-    	android:label="@string/app_name" android:debuggable="true">
+    <application
+        android:icon="@drawable/icon"
+        android:label="@string/app_name">
     	
         <activity 
         	android:name="SplashScreen" 


### PR DESCRIPTION
## Summary
- remove the hard-coded debuggable flag from the application manifest so release builds are not debuggable

## Testing
- ant release *(fails: Buildfile: build.xml does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68cff2c5b20083228cc8486e96567065