### PR TITLE
Use integer preference reads for signal levels

### DIFF
--- a/src/com/StupidRat/SysLvl/SysLvlDbAdapter.java
+++ b/src/com/StupidRat/SysLvl/SysLvlDbAdapter.java
@@ -258,8 +258,8 @@ public class SysLvlDbAdapter {
 		
 		//Get starting signal levels from user preferences
 		SharedPreferences prefs = context.getSharedPreferences(SysLvlActivity.SYSLVL_PREFS, 0);
-		incomingSignalHigh = Integer.parseInt(prefs.getString("HighFreqOutput", "45"));
-		incomingSignalLow = Integer.parseInt(prefs.getString("LowFreqOutput", "36"));
+                incomingSignalHigh = prefs.getInt("HighFreqOutput", 45);
+                incomingSignalLow = prefs.getInt("LowFreqOutput", 36);
 		
 		//Begin a loop that loads levels from a cursor, performs the calculations
 		//and saves the new levels.

--- a/src/com/StupidRat/SysLvl/SysLvlScreen.java
+++ b/src/com/StupidRat/SysLvl/SysLvlScreen.java
@@ -64,8 +64,8 @@ public class SysLvlScreen extends SysLvlActivity {
     	final SharedPreferences prefs = getSharedPreferences(SYSLVL_PREFS , MODE_PRIVATE);
     	TextView TextViewAmpOut = (TextView) findViewById(R.id.TextViewAmpOut);
     	
-    	int AmpOutHigh = Integer.parseInt(prefs.getString("HighFreqOutput", "45"));
-    	int AmpOutLow = Integer.parseInt(prefs.getString("LowFreqOutput", "36"));
+        int AmpOutHigh = prefs.getInt("HighFreqOutput", 45);
+        int AmpOutLow = prefs.getInt("LowFreqOutput", 36);
     	//int AmpOutLow = prefs.getInt("LowFreqOutput", 0);
     	String AmpOutText = "Starting "+AmpOutHigh+"/"+AmpOutLow;
     	TextViewAmpOut.setText(AmpOutText);


### PR DESCRIPTION
## Summary
- switch SysLvlScreen to retrieve high and low level outputs directly via SharedPreferences.getInt with default values
- update SysLvlDbAdapter attenuation recalculations to read integer preferences without manual parsing

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cffa8edac0832291f69dfdfa32db0a