### PR TITLE
Manage location updates in activity lifecycle

### DIFF
--- a/src/com/StupidRat/SysLvl/GeoNotesScreen.java
+++ b/src/com/StupidRat/SysLvl/GeoNotesScreen.java
@@ -28,8 +28,9 @@ public class GeoNotesScreen extends ListActivity {
 	private static final long MINIMUM_DISTANCE_CHANGE_FOR_UPDATES = 1; // in Meters
 	private static final long MINIMUM_TIME_BETWEEN_UPDATES = 1000; // in Milliseconds
 	
-	protected LocationManager locationManager;
-	protected Button retrieveLocationButton;
+        protected LocationManager locationManager;
+        protected Button retrieveLocationButton;
+        private LocationListener locationListener;
 	
     private static final int ACTIVITY_CREATE=0;
     private static final int ACTIVITY_EDIT=1;
@@ -62,20 +63,44 @@ public class GeoNotesScreen extends ListActivity {
         retrieveLocationButton = (Button) findViewById(R.id.retrieve_location_button);
         
         locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+        locationListener = new MyLocationListener();
         
-        locationManager.requestLocationUpdates(
-        		LocationManager.GPS_PROVIDER, 
-        		MINIMUM_TIME_BETWEEN_UPDATES, 
-        		MINIMUM_DISTANCE_CHANGE_FOR_UPDATES,
-        		new MyLocationListener()
-        );
-        
-		retrieveLocationButton.setOnClickListener(new OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				showCurrentLocation();
-			}
-		}); 
+                retrieveLocationButton.setOnClickListener(new OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                                showCurrentLocation();
+                        }
+                });
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        if (locationManager != null && locationListener != null) {
+                locationManager.requestLocationUpdates(
+                                LocationManager.GPS_PROVIDER,
+                                MINIMUM_TIME_BETWEEN_UPDATES,
+                                MINIMUM_DISTANCE_CHANGE_FOR_UPDATES,
+                                locationListener
+                );
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        if (locationManager != null && locationListener != null) {
+                locationManager.removeUpdates(locationListener);
+        }
+        super.onPause();
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (locationManager != null && locationListener != null) {
+                locationManager.removeUpdates(locationListener);
+        }
+        super.onDestroy();
     }
     
 	protected void showCurrentLocation() {


### PR DESCRIPTION
## Summary
- instantiate the `MyLocationListener` once and hold a reference for reuse
- start requesting GPS updates in `onResume`, guarding against a null `LocationManager`
- stop listening for updates in `onPause` and `onDestroy` to avoid leaks when the screen is backgrounded

## Testing
- Not run (legacy project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cffc9d04d483228491b2e9c8600d05