### PR TITLE
Persist captured geo note coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sequenceDiagram
 `GeoNotesScreen.showCurrentLocation()` snapshots the device's GPS reading into the local notes database and immediately refreshes the list.
 
 - **Inputs:** A `LocationManager` delivers `GPS_PROVIDER` updates every 1,000 ms or when the device has moved 1 meter, whichever comes first. When the user taps **Retrieve Location**, the screen pulls the last known fix and displays its reported accuracy.【F:src/com/StupidRat/SysLvl/GeoNotesScreen.java†L24-L86】
-- **Processing:** The method formats the longitude/latitude pair into a human-readable title and body, then calls `GeoNotesDbAdapter.createNote(...)` to persist the reading (plus placeholders for lat/long/street/state/zip fields) into the `notes` table.【F:src/com/StupidRat/SysLvl/GeoNotesScreen.java†L88-L137】【F:src/com/StupidRat/SysLvl/GeoNotesDbAdapter.java†L12-L104】
+- **Processing:** The method formats the longitude/latitude pair into a human-readable title and body, then calls `GeoNotesDbAdapter.createNote(...)` to persist the reading along with the captured latitude/longitude strings and any reverse-geocoded street/state/zip metadata when available.【F:src/com/StupidRat/SysLvl/GeoNotesScreen.java†L88-L153】【F:src/com/StupidRat/SysLvl/GeoNotesDbAdapter.java†L12-L104】
 - **Outputs:** After writing, it invokes `fillData()` to query all notes and bind them to the `ListView` through a `SimpleCursorAdapter`, ensuring the newest snapshot is visible immediately.【F:src/com/StupidRat/SysLvl/GeoNotesScreen.java†L139-L193】
 
 ```mermaid
@@ -75,3 +75,9 @@ Downstream services should continue to honor the following persisted configurati
 - GPS updates arrive from `LocationManager.GPS_PROVIDER` every 1 second (`MINIMUM_TIME_BETWEEN_UPDATES = 1000`) or 1 meter of movement (`MINIMUM_DISTANCE_CHANGE_FOR_UPDATES = 1`). Services consuming these notes should assume snapshots can be as frequent as this cadence, though captures only occur when the user explicitly requests them.【F:src/com/StupidRat/SysLvl/GeoNotesScreen.java†L24-L115】
 
 Maintaining these assumptions ensures the existing attenuation calculations and geo-note synchronization logic stay aligned as the system evolves.
+
+### Manual Test: Geo Note Coordinate Persistence
+
+1. Launch **GeoNotesScreen** and tap **Retrieve Location** to capture a new note.
+2. Open the created entry in **GeoNoteEdit**.
+3. Confirm the latitude and longitude fields display the stored coordinate strings from the captured fix.

--- a/src/com/StupidRat/SysLvl/GeoNotesScreen.java
+++ b/src/com/StupidRat/SysLvl/GeoNotesScreen.java
@@ -1,14 +1,18 @@
 package com.StupidRat.SysLvl;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import android.Manifest;
 import android.app.ListActivity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.location.Address;
+import android.location.Geocoder;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
@@ -25,6 +29,7 @@ import android.widget.ListView;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.util.Log;
 
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -162,11 +167,28 @@ public class GeoNotesScreen extends ListActivity {
 
                         String message = "";
                         String body = "";
-                        String latitude = "";
-                        String longitude = "";
-                        String street = "";
-                        String state = "";
-                        String zip = "";
+                        String latitude = String.valueOf(location.getLatitude());
+                        String longitude = String.valueOf(location.getLongitude());
+                        String street = null;
+                        String state = null;
+                        String zip = null;
+
+                        Geocoder geocoder = new Geocoder(this, Locale.getDefault());
+                        try {
+                            List<Address> addresses = geocoder.getFromLocation(location.getLatitude(),
+                                    location.getLongitude(), 1);
+                            if (addresses != null && !addresses.isEmpty()) {
+                                Address address = addresses.get(0);
+                                street = address.getThoroughfare();
+                                if (street == null) {
+                                    street = address.getFeatureName();
+                                }
+                                state = address.getAdminArea();
+                                zip = address.getPostalCode();
+                            }
+                        } catch (IOException e) {
+                            Log.w("GeoNotesScreen", "Reverse geocoding failed", e);
+                        }
 
 
                         message = String.format("Longitude: %1$s \n Latitude: %2$s",


### PR DESCRIPTION
## Summary
- persist the captured latitude and longitude strings when creating geo notes so stored records retain their GPS fix
- reverse geocode the current fix to attach street, state, and zip metadata when available while gracefully handling failures
- document the manual verification flow for confirming coordinates display in GeoNoteEdit

## Testing
- ./gradlew test --console=plain > /tmp/gradle-test.log && tail -n 20 /tmp/gradle-test.log

------
https://chatgpt.com/codex/tasks/task_e_68d1ea6cefe88322ad2e57dddb98d27a