### PR TITLE
Ensure spans retain ordering when fetched

### DIFF
--- a/src/com/StupidRat/SysLvl/SysLvlDbAdapter.java
+++ b/src/com/StupidRat/SysLvl/SysLvlDbAdapter.java
@@ -75,8 +75,8 @@ public class SysLvlDbAdapter {
 	public Cursor fetchAllSpans() {
 		Log.v(SysLvlActivity.DEBUG_TAG, "fetchAllSpans");
 
-		String sql = "SELECT * FROM " + SPANS_TABLE + " WHERE " + KEY_POSITION
-				+ " >= 0 GROUP BY position";
+                String sql = "SELECT * FROM " + SPANS_TABLE + " WHERE " + KEY_POSITION
+                                + " >= 0 ORDER BY " + KEY_POSITION + " ASC";
 		Log.v(SysLvlActivity.DEBUG_TAG, sql);
 
 		return database.rawQuery(sql, null);


### PR DESCRIPTION
## Summary
- replace the Spans query grouping in `SysLvlDbAdapter.fetchAllSpans` with an ascending order clause so callers receive every row in positional order.

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d2b4e954d883228fb8d179d32a20ee