### PR TITLE
Modernize list row item layout

### DIFF
--- a/gen/com/StupidRat/SysLvl/R.java
+++ b/gen/com/StupidRat/SysLvl/R.java
@@ -206,9 +206,11 @@ containing a value of this type.
         public static final int l_list=0x7f0b004c;
         public static final int label=0x7f0b001e;
         public static final int retrieve_location_button=0x7f0b0010;
+        public static final int retrieve_location_progress_chip=0x7f0b004d;
         public static final int scannerBtn=0x7f0b0005;
         public static final int scroll=0x7f0b002f;
-        public static final int t_name=0x7f0b0020;
+        public static final int primary_text=0x7f0b0050;
+        public static final int secondary_text=0x7f0b0051;
         public static final int text1=0x7f0b002c;
         public static final int textView1=0x7f0b0004;
         public static final int textView2=0x7f0b0002;
@@ -262,6 +264,7 @@ containing a value of this type.
         public static final int menu_item_play=0x7f090010;
         public static final int menu_item_scores=0x7f090011;
         public static final int menu_item_settings=0x7f09000f;
+        public static final int more=0x7f09001a;
         public static final int no_notes=0x7f090001;
         public static final int ongoing_blank=0x7f090015;
         public static final int settings=0x7f09000b;

--- a/res/layout/list.xml
+++ b/res/layout/list.xml
@@ -1,28 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="wrap_content"
-	android:layout_height="wrap_content"
-	android:paddingLeft="5dp"
-	android:paddingRight="5dp"
-	android:paddingTop="10dp"
-	android:paddingBottom="10dp"
-	android:gravity="center_vertical">
-  
-  	<ImageView
-  		android:id="@+id/i_more"
-  		android:layout_alignParentRight="true"
-  		android:layout_width="wrap_content"
-  		android:layout_height="wrap_content"
-  		android:src="@drawable/ic_list_more"/>
-  	
-  	<TextView
-  		android:id="@+id/t_name"
-  		android:layout_alignParentLeft="true"
-  		android:layout_toLeftOf="@id/i_more"
-  		android:layout_width="wrap_content"
-  		android:layout_height="wrap_content"
-  		android:text="Text"
-  		android:textColor="#FFFFFF"/>
-  		
-</RelativeLayout>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="8dp"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardElevation="2dp"
+    app:cardUseCompatPadding="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/primary_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                android:textColor="?attr/colorOnSurface" />
+
+            <TextView
+                android:id="@+id/secondary_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                android:textColor="?attr/colorOnSurface" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/i_more"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/more"
+            android:padding="4dp"
+            android:src="@drawable/ic_list_more" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="menu_item_play">Play Game</string>
     <string name="menu_item_scores">View Scores</string>
     <string name="menu_item_help">Help</string>
+    <string name="more">More options</string>
     <string name="summary_blank">Cable:none \nLenght:000ft \nDevice:none </string>
     <string name="tap_blank">Out of Tap\nHigh Mhz:00.0\nLow Mhz:00.0</string>
     <string name="ongoing_blank">Ongoing\nHigh Mhz:00.0\nLow Mhz:00.0</string>

--- a/src/com/StupidRat/SysLvl/NewQAAdapter.java
+++ b/src/com/StupidRat/SysLvl/NewQAAdapter.java
@@ -1,64 +1,86 @@
 package com.StupidRat.SysLvl;
 
-
+import android.content.Context;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.LayoutInflater;
-
-import android.content.Context;
-
 import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 public class NewQAAdapter extends BaseAdapter {
-	private LayoutInflater mInflater;
-	private String[] data;
-	
-	public NewQAAdapter(Context context) { 
-		mInflater = LayoutInflater.from(context);
-	}
+        private final LayoutInflater mInflater;
+        private String[] data;
 
-	public void setData(String[] data) {
-		this.data = data;
-	}
-	
-	@Override
-	public int getCount() {
-		return data.length;
-	}
+        public NewQAAdapter(Context context) {
+                mInflater = LayoutInflater.from(context);
+                data = new String[0];
+        }
 
-	@Override
-	public Object getItem(int item) {
-		return data[item];
-	}
+        public void setData(String[] data) {
+                if (data == null) {
+                        this.data = new String[0];
+                } else {
+                        this.data = data;
+                }
+        }
 
-	@Override
-	public long getItemId(int position) {
-		return position;
-	}
+        @Override
+        public int getCount() {
+                return data != null ? data.length : 0;
+        }
 
-	@Override
-	public View getView(int position, View convertView, ViewGroup parent) {
-		ViewHolder holder;
-		
-		if (convertView == null) {
-			convertView	= mInflater.inflate(R.layout.list, null);
-			
-			holder 		= new ViewHolder();
-			
-			holder.mTitleText	= (TextView) convertView.findViewById(R.id.t_name);
-			
-			convertView.setTag(holder);
-		} else {
-			holder = (ViewHolder) convertView.getTag();
-		}
+        @Override
+        public Object getItem(int item) {
+                return data != null ? data[item] : null;
+        }
 
-		holder.mTitleText.setText(data[position]);
-		
-		return convertView;
-	}
+        @Override
+        public long getItemId(int position) {
+                return position;
+        }
 
-	static class ViewHolder {
-		TextView mTitleText;
-	}
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+                ViewHolder holder;
+
+                if (convertView == null) {
+                        convertView = mInflater.inflate(R.layout.list, parent, false);
+
+                        holder = new ViewHolder();
+                        holder.primaryText = (TextView) convertView.findViewById(R.id.primary_text);
+                        holder.secondaryText = (TextView) convertView.findViewById(R.id.secondary_text);
+
+                        convertView.setTag(holder);
+                } else {
+                        holder = (ViewHolder) convertView.getTag();
+                }
+
+                String item = data[position];
+                String primary = item;
+                String secondary = "";
+
+                if (item != null) {
+                        int separatorIndex = item.indexOf('\n');
+                        if (separatorIndex >= 0) {
+                                primary = item.substring(0, separatorIndex).trim();
+                                secondary = item.substring(separatorIndex + 1).trim();
+                        }
+                }
+
+                holder.primaryText.setText(primary);
+                if (secondary.length() > 0) {
+                        holder.secondaryText.setVisibility(View.VISIBLE);
+                        holder.secondaryText.setText(secondary);
+                } else {
+                        holder.secondaryText.setVisibility(View.GONE);
+                        holder.secondaryText.setText(null);
+                }
+
+                return convertView;
+        }
+
+        static class ViewHolder {
+                TextView primaryText;
+                TextView secondaryText;
+        }
 }


### PR DESCRIPTION
## Summary
- replace the legacy list row with a MaterialCardView surface that fills the width and adopts Material3 text appearances
- bind primary and secondary summary lines separately in `NewQAAdapter` with safe defaults for empty data
- add supporting resources for the refreshed layout, including an accessible content description for the action icon

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68d2dbf6f28083228683fa885a7d262d